### PR TITLE
Add support for workspaces with multiple folders configured

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export interface IConfigWorkspaceFolders {[key: string]: boolean}
+
 export interface IConfig {
   showImageTypes: string[],
   keyword: string,
@@ -6,4 +8,5 @@ export interface IConfig {
   size: number,
   includeFolders: string[],
   excludeFolders: string[],
+  includeProjectFolders: IConfigWorkspaceFolders,
 }

--- a/src/webview/PreviewImages/SettingsModal/index.tsx
+++ b/src/webview/PreviewImages/SettingsModal/index.tsx
@@ -1,38 +1,53 @@
-import { Modal, Button, Input, Space } from "antd";
+import { Modal, Button, Input, Space, Checkbox } from "antd";
 import React, { FC } from "react";
 import { useState } from "react";
+import { IConfigWorkspaceFolders } from "types";
 
 const { TextArea } = Input;
 
 interface ISettingsModalProps {
   includeFolders: string[];
   excludeFolders: string[];
+  includeProjectFolders: IConfigWorkspaceFolders;
   visible: boolean;
   // eslint-disable-next-line no-unused-vars
-  onApply: (includeFolders: string[], excludeFolders: string[]) => void;
+  onApply: (includeFolders: string[], excludeFolders: string[], includeProjectFolders: IConfigWorkspaceFolders) => void;
   onClose: () => void;
 }
 
 const SettingsModal: FC<ISettingsModalProps> = ({
   includeFolders: initIncludeFolders,
   excludeFolders: initExcludeFolders,
+  includeProjectFolders: initIncludeProjectFolders,
   visible,
   onApply,
   onClose
 }) => {
   const [includeFolders, setIncludeFolders] = useState<string>(initIncludeFolders.join("\n"));
   const [excludeFolders, setExcludeFolders] = useState<string>(initExcludeFolders.join("\n"));
+  const [includeProjectFolders, setIncludeProjectFolders] = useState<IConfigWorkspaceFolders>(initIncludeProjectFolders);
 
   const handleApply = () => {
     const includeFoldersArray = includeFolders.split("\n").map(i => i.trim()).filter(i => i);
     const excludeFoldersArray = excludeFolders.split("\n").map(i => i.trim()).filter(i => i);
-    onApply(includeFoldersArray, excludeFoldersArray);
+    onApply(includeFoldersArray, excludeFoldersArray, includeProjectFolders);
     onClose();
   };
 
+  const projectFolderKeys = Object.keys(includeProjectFolders);
+
   return (
     <Modal title='Settings' open={visible} onCancel={onClose} footer={null} destroyOnClose>
-      <div>Enter directories to <b>include</b> in search, one per line</div>
+      {projectFolderKeys.length > 1 && [
+        <div>Choose which project folders to search</div>,
+        projectFolderKeys.map((folder) => {
+          const checked = includeProjectFolders[folder];
+          return <Checkbox checked={checked} onChange={(e) => setIncludeProjectFolders(Object.assign({}, includeProjectFolders, {[folder]:!checked}))}>
+            {folder.substring(folder.lastIndexOf('/') + 1)}
+          </Checkbox>
+        }),
+      ]}
+      <div style={projectFolderKeys.length > 1 ? { margin: '20px 0 0 0' } : undefined}>Enter directories to <b>include</b> in search, one per line</div>
       <TextArea
         autoSize={{ minRows: 5, maxRows: 10 }}
         placeholder="e.g. assets"

--- a/src/webviewController/imagesViewer/config.ts
+++ b/src/webviewController/imagesViewer/config.ts
@@ -13,7 +13,7 @@ const DEFAULT_CONFIG: IConfig = {
   size: 100,
   includeFolders: [],
   excludeFolders: [],
-
+  includeProjectFolders: {},
 }
 
 const PROJECTS_CONFIG_DIRECTORY = 'projectsConfig'

--- a/src/webviewController/imagesViewer/index.ts
+++ b/src/webviewController/imagesViewer/index.ts
@@ -3,8 +3,8 @@ import { ViewColumn, Webview } from 'vscode'
 import { utils, webviewUtils } from '@easy_vscode/core'
 import { IWebview, IWebviewProps, IMessage } from '@easy_vscode/core/lib/types'
 import { DIST_WEBVIEW_INDEX_HTML, EXTENSION_COMMANDS, MESSAGE_CMD, WEBVIEW_NAMES } from '../../constants'
-import { getAllImgs, getImageBase64, getImageSize } from './utils'
-import { readLocalConfigFile, writeLocalConfigFile } from './config'
+import { getAllImgs, getAllProjectPaths, getImageBase64, getImageSize, makeAbsoluteProjectPath, readValidatedConfigFile } from './utils'
+import { writeLocalConfigFile } from './config'
 
 const { deleteFile, getProjectPath, renameFile } = utils
 const { invokeCallback, successResp } = webviewUtils
@@ -31,7 +31,7 @@ const messageHandlers = new Map([
     MESSAGE_CMD.GET_ALL_IMGS,
     (message: IMessage, webview: Webview) => {
       const imgs = getAllImgs(webview)
-      invokeCallback(viewType, message, { imgs, projectPath: getProjectPath() })
+      invokeCallback(viewType, message, { imgs, projectPaths: getAllProjectPaths() })
     }
   ],
   [
@@ -51,7 +51,8 @@ const messageHandlers = new Map([
   [
     MESSAGE_CMD.OPEN_IMAGE_DIRECTORY,
     (message: IMessage) => {
-      exec(`open ${getProjectPath()}/${message.data.path}`)
+      // This needs to be 'explorer' on windows, 'xdg-open' (I think) on Linux
+      exec(`open ${makeAbsoluteProjectPath(message.data.path).replace(/\//g, '\\')}`)
     }
   ],
   [
@@ -77,7 +78,7 @@ const messageHandlers = new Map([
   ],
   [
     MESSAGE_CMD.GET_CONFIG,
-    (message: IMessage) => invokeCallback(viewType, message, readLocalConfigFile())
+    (message: IMessage) => invokeCallback(viewType, message, readValidatedConfigFile())
   ],
 ])
 

--- a/src/webviewController/imagesViewer/utils.ts
+++ b/src/webviewController/imagesViewer/utils.ts
@@ -1,16 +1,17 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { Webview, Uri } from 'vscode'
-import { utils } from '@easy_vscode/core'
 import imageSize from 'image-size'
 import { readLocalConfigFile } from './config'
+import * as vscode from 'vscode'
+import { IConfigWorkspaceFolders } from 'types'
 
 export const SUPPORT_IMG_TYPES = ['.svg', '.png', '.jpeg', '.jpg', '.ico', '.gif', '.webp', '.bmp', '.tif', '.tiff', '.apng', '.avif']
-const { getProjectPath } = utils
 
 
 
 interface IImage {
+  projectDir: string;
   path: string
   vscodePath: string
   size: number
@@ -31,11 +32,13 @@ const removeFirstSlash = (path: string) => path.startsWith('/') ? path.slice(1) 
  */
 const removeSlash = (path: string) => removeLastSlash(removeFirstSlash(path))
 
-function searchImgs(basePath: string, includeFolders: string[], excludeFolders: string[], webview: Webview) {
+function searchImgs(basePath: string, includeFolders: string[], excludeFolders: string[], webview: Webview, workspacePath: string) {
   // const imgs: any = new Map<string, IImage>()
   const imgs: IImage[] = []
   const searchedFolders = new Set<string>()
   const excludeFoldersSet = new Set(excludeFolders.map(folder => basePath + '/' + removeSlash(folder)))
+  const projectDir = workspacePath.substring(workspacePath.lastIndexOf('/') + 1)
+
   // eslint-disable-next-line no-unused-vars
   const dfs = (pathname: string, callback: (filePath: string) => void) => {
     try {
@@ -69,6 +72,7 @@ function searchImgs(basePath: string, includeFolders: string[], excludeFolders: 
       // vscodePath e.g. https://file%2B.vscode-resource.vscode-cdn.net/Users/user_name/project_dir/src/favicon.ico
       const vscodePath = webview.asWebviewUri(Uri.file(filePath)).toString()
       const img = {
+        projectDir,
         path: relativePath,
         vscodePath,
         size
@@ -80,14 +84,52 @@ function searchImgs(basePath: string, includeFolders: string[], excludeFolders: 
 }
 
 /**
+ * get all workspace folders, not just the first as returned by getProjectPath
+ */
+export const getAllProjectPaths = () => {
+  return vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders.map((folder) => folder.uri.fsPath.replace(/\\/g, '/')) : [];
+}
+
+/**
+ * converts a relative path back to an absolute path while attempting to match it to a project path if multiple exists
+ */
+export const makeAbsoluteProjectPath = (path: string) => {
+  const projectPaths = getAllProjectPaths();
+  if (projectPaths.length == 1)
+    return projectPaths[0] + path;
+
+  const projectDir = path.substring(path.startsWith('/') ? 1 : 0, path.indexOf('/'))
+  const projectPath = projectPaths.find((path) => path.endsWith(projectDir))
+  return projectPath ? projectPath.substring(0, projectPath.lastIndexOf('/') + 1) + path : path;
+}
+
+/**
+ * reads the config file and preprocesses it to ensure the contents are valid against current workspace
+ */
+export const readValidatedConfigFile = () => {
+  const config = readLocalConfigFile()
+  const projectPaths = getAllProjectPaths();
+
+  // ensure we have entires for all project files and remove ones which no longer exist
+  if (!config.includeProjectFolders)
+    config.includeProjectFolders = {};
+  config.includeProjectFolders = Object.assign({}, ...projectPaths.map((folder) => ({ [folder]: config.includeProjectFolders[folder] ?? true })));
+  return config;
+}
+
+/**
  * get all imgs
  */
 export const getAllImgs = (webview: Webview) => {
-  const config = readLocalConfigFile()
-  const { includeFolders, excludeFolders } = config
-  const basePath = getProjectPath()
+  const config = readValidatedConfigFile()
+  const { includeFolders, excludeFolders, includeProjectFolders } = config
+  const includeProjectFoldersKeys = Object.keys(includeProjectFolders).filter((folder) => includeProjectFolders[folder]);
+  const hasMultipleFolders = includeProjectFoldersKeys.length > 1;
+
   const beginTime = new Date()
-  const imgs = searchImgs(basePath, includeFolders, excludeFolders, webview)
+  // ES2019: replace with .map and .flat
+  let imgs: IImage[] = [];
+  includeProjectFoldersKeys.forEach(folder => imgs = [...imgs, ...searchImgs(folder, includeFolders, excludeFolders, webview, hasMultipleFolders ? folder : '')]);
   const endTime = new Date()
   console.log(`${imgs.length} images found in ${(endTime.getTime() - beginTime.getTime())}ms`)
   return imgs


### PR DESCRIPTION
- search for images in all workspace folders
- add checkboxes to settings dialog to enable/disable folders
- save above to config
- changes to path handling in viewer to avoid grouping subfolders from different workspaces together incorrectly and support relative->absolute path rebuilding without assuming a single workspace dir