### PR TITLE
Remove a space to avoid image loading errors on WeChat Mini Program when copy Base64 string

### DIFF
--- a/src/webviewController/imagesViewer/utils.ts
+++ b/src/webviewController/imagesViewer/utils.ts
@@ -101,7 +101,7 @@ export const getImageBase64 = (filePath: string): string => {
     tif: 'tiff'
   }
   imgType = map[imgType] ?? imgType
-  const imgBase64 = `data: image/${imgType};base64,` + Buffer.from(bitmap).toString('base64')
+  const imgBase64 = `data:image/${imgType};base64,` + Buffer.from(bitmap).toString('base64')
   return imgBase64
 }
 


### PR DESCRIPTION
![image](https://github.com/ZhangJian1713/vscode-image-viewer/assets/43309591/3757d046-c753-4c74-a1d5-a34916a5fe5c)
The space in `data: image/` on WeChat Mini Program will be replaced with '%20'